### PR TITLE
Fix login form async await

### DIFF
--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -121,9 +121,9 @@ async function tryLogin() {
   
 }
 
-function sendLogin()
+async function sendLogin()
 {
-  if (tryLogin())
+  if (await tryLogin())
   {
     router.push({name: 'index'})
   }


### PR DESCRIPTION
## Summary
- fix login form to await login before redirecting

## Testing
- `npm run build` *(fails: Cannot find module 'pathe')*

------
https://chatgpt.com/codex/tasks/task_e_6859b6a7c074832d82d6b5db683f2535