### PR TITLE
Fix login API response check

### DIFF
--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -77,7 +77,7 @@ async function tryLogin() {
       })
 
   // check for error
-  if (typeof response.code !== 'undefined') {
+  if (!response.ok) {
     loginError.value = defaultLoginErrorMsg.value
     return false
   }


### PR DESCRIPTION
## Summary
- update `LoginForm.vue` to check `response.ok` instead of undefined `response.code`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6859b98fc5bc832dac2af6a9ca4bc1e0